### PR TITLE
fix base64 bug

### DIFF
--- a/xmlrpc.go
+++ b/xmlrpc.go
@@ -197,7 +197,7 @@ func to_xml(v interface{}, typ bool) (s string) {
 	k := t.Kind()
 
 	if b, ok := v.([]byte); ok {
-		return base64.StdEncoding.EncodeToString(b)
+		return "<base64>" + base64.StdEncoding.EncodeToString(b) + "</base64>"
 	}
 
 	switch k {


### PR DESCRIPTION
if the value's type is byte[], xml should have base64 tag
