### PR TITLE
Fix parsing of arrays containing structs

### DIFF
--- a/xmlrpc.go
+++ b/xmlrpc.go
@@ -163,13 +163,17 @@ func next(p *xml.Decoder) (xml.Name, interface{}, error) {
 	case "array":
 		var ar Array
 		nextStart(p) // data
+		nextStart(p) // top of value
 		for {
-			nextStart(p) // top of value
 			_, value, e := next(p)
 			if e != nil {
 				break
 			}
 			ar = append(ar, value)
+
+			if reflect.ValueOf(value).Kind() != reflect.Map {
+				nextStart(p)
+			}
 		}
 		return xml.Name{}, ar, nil
 	case "nil":

--- a/xmlrpc_test.go
+++ b/xmlrpc_test.go
@@ -146,3 +146,206 @@ func TestAddString(t *testing.T) {
 		t.Fatalf("want %q but got %q", "helloworld", v)
 	}
 }
+
+type ParseStructArrayHandler struct {
+}
+
+func (h *ParseStructArrayHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Write([]byte(`
+<?xml version="1.0"?>
+<methodResponse>
+  <params>
+    <param>
+      <value>
+        <array>
+          <data>
+            <value>
+              <struct>
+                <member>
+                  <name>test1</name>
+                  <value>
+                    <string>a</string>
+                  </value>
+                </member>
+                <member>
+                  <name>test2</name>
+                  <value>
+                    <int>2</int>
+                  </value>
+                </member>
+              </struct>
+            </value>
+            <value>
+              <struct>
+                <member>
+                  <name>test1</name>
+                  <value>
+                    <string>b</string>
+                  </value>
+                </member>
+                <member>
+                  <name>test2</name>
+                  <value>
+                    <int>2</int>
+                  </value>
+                </member>
+              </struct>
+            </value>
+            <value>
+              <struct>
+                <member>
+                  <name>test1</name>
+                  <value>
+                    <string>c</string>
+                  </value>
+                </member>
+                <member>
+                  <name>test2</name>
+                  <value>
+                    <int>2</int>
+                  </value>
+                </member>
+              </struct>
+            </value>
+          </data>
+        </array>
+      </value>
+    </param>
+  </params>
+</methodResponse>
+		`))
+}
+
+func TestParseStructArray(t *testing.T) {
+	ts := httptest.NewServer(&ParseStructArrayHandler{})
+	defer ts.Close()
+
+	res, err := NewClient(ts.URL + "/").Call("Irrelevant")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(res.(Array)) != 3 {
+		t.Fatal("expected array with 3 entries")
+	}
+}
+
+type ParseIntArrayHandler struct {
+}
+
+func (h *ParseIntArrayHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Write([]byte(`
+<?xml version="1.0"?>
+<methodResponse>
+  <params>
+    <param>
+      <value>
+        <array>
+          <data>
+            <value>
+              <int>2</int>
+            </value>
+            <value>
+              <int>3</int>
+            </value>
+            <value>
+              <int>4</int>
+            </value>
+          </data>
+        </array>
+      </value>
+    </param>
+  </params>
+</methodResponse>
+		`))
+}
+
+func TestParseIntArray(t *testing.T) {
+	ts := httptest.NewServer(&ParseIntArrayHandler{})
+	defer ts.Close()
+
+	res, err := NewClient(ts.URL + "/").Call("Irrelevant")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(res.(Array)) != 3 {
+		t.Fatal("expected array with 3 entries")
+	}
+}
+
+type ParseMixedArrayHandler struct {
+}
+
+func (h *ParseMixedArrayHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Write([]byte(`
+<?xml version="1.0"?>
+<methodResponse>
+  <params>
+    <param>
+      <value>
+        <array>
+          <data>
+            <value>
+              <struct>
+                <member>
+                  <name>test1</name>
+                  <value>
+                    <string>a</string>
+                  </value>
+                </member>
+                <member>
+                  <name>test2</name>
+                  <value>
+                    <int>2</int>
+                  </value>
+                </member>
+              </struct>
+            </value>
+            <value>
+              <int>2</int>
+            </value>
+            <value>
+              <struct>
+                <member>
+                  <name>test1</name>
+                  <value>
+                    <string>b</string>
+                  </value>
+                </member>
+                <member>
+                  <name>test2</name>
+                  <value>
+                    <int>2</int>
+                  </value>
+                </member>
+              </struct>
+            </value>
+            <value>
+              <int>4</int>
+            </value>
+          </data>
+        </array>
+      </value>
+    </param>
+  </params>
+</methodResponse>
+		`))
+}
+
+func TestParseMixedArray(t *testing.T) {
+	ts := httptest.NewServer(&ParseMixedArrayHandler{})
+	defer ts.Close()
+
+	res, err := NewClient(ts.URL + "/").Call("Irrelevant")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(res.(Array)) != 4 {
+		t.Fatal("expected array with 4 entries")
+	}
+}


### PR DESCRIPTION
Arrays containing structs seem to not get parsed correctly currently. After parsing one struct entry the pointer already references the next `value` in the array, causing the `nextStart(p)`-Call to move the pointer to the `struct`-Entry. Thereby all array entries after the struct get cut.

This is an attempt to fix that. It would probably be cleaner to avoid moving the pointer too far when handling the struct, but I'm not sure how to do that.