### PR TITLE
Fix call() using global httpClient

### DIFF
--- a/xmlrpc.go
+++ b/xmlrpc.go
@@ -319,7 +319,7 @@ func makeRequest(name string, args ...interface{}) *bytes.Buffer {
 }
 
 func call(client *http.Client, url, name string, args ...interface{}) (v interface{}, e error) {
-	r, e := httpClient.Post(url, "text/xml", makeRequest(name, args...))
+	r, e := client.Post(url, "text/xml", makeRequest(name, args...))
 	if e != nil {
 		return nil, e
 	}


### PR DESCRIPTION
I found that `call()` uses global httpClient instead of one which is passed as first argument `client *http.Client`.

Bonus: fixing this also allows to define http.Client with unix socket transport, which allows prometheus node_exporter connecting to supervisord via unix socket.