### PR TITLE
Allow self-signed SSL

### DIFF
--- a/xmlrpc.go
+++ b/xmlrpc.go
@@ -360,9 +360,11 @@ func (c *Client) Call(name string, args ...interface{}) (v interface{}, e error)
 	return call(c.HttpClient, c.url, name, args...)
 }
 
-// Global httpClient allows us to pool/reuse connections and not wastefully
-// re-create transports for each request.
+// Set this to true if you want to disable SSL verification
 var InsecureSkipVerify = false
+
+// Global HttpClient allows us to pool/reuse connections and not wastefully
+// re-create transports for each request.
 var HttpClient = &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: InsecureSkipVerify}}, Timeout: 10 * time.Second}
 
 // Call call remote procedures function name with args

--- a/xmlrpc.go
+++ b/xmlrpc.go
@@ -361,9 +361,10 @@ func (c *Client) Call(name string, args ...interface{}) (v interface{}, e error)
 
 // Global httpClient allows us to pool/reuse connections and not wastefully
 // re-create transports for each request.
-var httpClient = &http.Client{Transport: http.DefaultTransport, Timeout: 10 * time.Second}
+var InsecureSkipVerify = false
+var HttpClient = &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: InsecureSkipVerify}}, Timeout: 10 * time.Second}
 
 // Call call remote procedures function name with args
 func Call(url, name string, args ...interface{}) (v interface{}, e error) {
-	return call(httpClient, url, name, args...)
+	return call(HttpClient, url, name, args...)
 }

--- a/xmlrpc.go
+++ b/xmlrpc.go
@@ -2,6 +2,7 @@ package xmlrpc
 
 import (
 	"bytes"
+	"crypto/tls"
 	"encoding/base64"
 	"encoding/xml"
 	"errors"


### PR DESCRIPTION
This would allow to place own http client as well as adds an option to bypass SSL check, in case this library is used on the internal networks with self-signed SSLs etc.